### PR TITLE
Fix spelling 'lenght' --> 'length'

### DIFF
--- a/flake8_functions/checker.py
+++ b/flake8_functions/checker.py
@@ -4,7 +4,7 @@ from typing import Generator, Tuple, Union, List
 
 from flake8_functions import __version__ as version
 from flake8_functions.function_purity import check_purity_of_functions
-from flake8_functions.function_lenght import get_length_errors
+from flake8_functions.function_length import get_length_errors
 from flake8_functions.function_arguments_amount import get_arguments_amount_error
 from flake8_functions.function_returns_amount import get_returns_amount_error
 

--- a/flake8_functions/function_length.py
+++ b/flake8_functions/function_length.py
@@ -28,11 +28,11 @@ def get_function_last_row(func_def: AnyFuncdef) -> int:
 def get_length_errors(func_def: AnyFuncdef, max_function_length: int) -> Tuple[int, int, str]:
     function_start_row = get_function_start_row(func_def)
     function_last_row = get_function_last_row(func_def)
-    function_lenght = function_last_row - function_start_row + 1
-    if function_lenght > max_function_length:
+    function_length = function_last_row - function_start_row + 1
+    if function_length > max_function_length:
         return (
             func_def.lineno,
             func_def.col_offset,
-            f'CFQ001 Function {func_def.name} has length {function_lenght}'
+            f'CFQ001 Function {func_def.name} has length {function_length}'
             f' that exceeds max allowed length {max_function_length}',
         )


### PR DESCRIPTION
Misspelled filename, plus function name and variables within the function `get_length_errors()`